### PR TITLE
Convert custom html modules to hugo shortcodes & mysql fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
     <name>Hugo-Joomla</name>
     <description>Hugo generation from Joomla database</description>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>30.0-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -124,7 +124,7 @@ public class JoomlaHugoConverter {
                 nastyContentChecker.checkForNastyContent(c);
                 Path path = Paths.get(pathToOutput);
                 logger.info("processing {} {} {}", c.getTitle(), c.getCategory(), c.getAlias());
-                Path newPath = path.resolve(c.getCategory());
+                Path newPath = path.resolve("content/" + c.getCategory());
                 newPath.toFile().mkdirs();
                 buildTomlOutput(c, newPath.resolve(c.getAlias() + ".md"), this.contentTemplate, this.htmltomarkdown);
             });
@@ -172,7 +172,7 @@ public class JoomlaHugoConverter {
             nastyContentChecker.checkForNastyContent(c);
             Path path = Paths.get(pathToOutput);
             logger.info("processing category {} {} {}", c.getTitle(), c.getCategory(), c.getAlias());
-            Path newPath = path.resolve(c.getParent() + ".md");
+            Path newPath = path.resolve("content/" + c.getParent() + ".md");
             buildTomlOutput(c, newPath, categoryTemplate, false);
         });
 

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -15,10 +15,12 @@ import io.github.furstenheim.HeadingStyle;
 import io.github.furstenheim.CodeBlockStyle;
 
 import java.io.BufferedWriter;
-import java.io.FileWriter;
+import java.io.OutputStreamWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +198,7 @@ public class JoomlaHugoConverter {
             root.put("joomlaData", content);
             root.put("tags", tagsQuoted);
             root.put("body", body);
-            template.process(root, new BufferedWriter(new FileWriter(resolve.toFile())));
+            template.process(root, new BufferedWriter(new OutputStreamWriter(new FileOutputStream(resolve.toFile(), true), StandardCharsets.UTF_8)));
         } catch (Exception e) {
             logger.error("Failed to generate file", e);
         }

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -208,7 +208,7 @@ public class JoomlaHugoConverter {
             logger.info("processing custom HTML module {}", c.getTitle());
             Path newPath = path.resolve("layout/shortcodes");
             newPath.toFile().mkdirs();
-            buildTomlOutput(c, newPath.resolve(c.getAlias() + ".md"), customHtmlModuleTemplate, false);
+            buildTomlOutput(c, newPath.resolve(this.sanitizeFilename(c.getAlias()) + ".md"), customHtmlModuleTemplate, false);
 
             
         });
@@ -283,5 +283,15 @@ public class JoomlaHugoConverter {
             }
         }
         return body;
+    }
+
+    private String sanitizeFilename(String inputName) {
+        //Replace all non a-zA-Z0-9-_ chars, convert string to lowercase, remove trailing _ after conversion
+        StringBuilder sb = new StringBuilder(inputName.replaceAll("[^a-zA-Z0-9-_]", "_").toLowerCase());
+        while (sb.length() > 0 && sb.charAt(sb.length() - 1) == '_') {
+            sb.setLength(sb.length() - 1);
+        }
+        
+        return sb.toString();
     }
 }

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -40,6 +40,7 @@ public class JoomlaHugoConverter {
 
     private final Template contentTemplate;
     private final Template categoryTemplate;
+    private final Template customHtmlModuleTemplate;
     private final Multimap<Integer, String> tagsByName = LinkedListMultimap.create(100);
     private final String dbExtension;
 
@@ -63,6 +64,7 @@ public class JoomlaHugoConverter {
 
         categoryTemplate = cfg.getTemplate("categoryPage.yaml.ftl");
         contentTemplate = cfg.getTemplate("defaultPage.yaml.ftl");
+        customHtmlModuleTemplate = cfg.getTemplate("customHtmlModule.yaml.ftl");
 
         buildTags();
     }
@@ -132,6 +134,7 @@ public class JoomlaHugoConverter {
             );
 
             performCategoryConversion();
+            performCustomHtmlModulesConversion();
 
             logger.info("Finished conversion of Joomla database");
         }
@@ -176,6 +179,42 @@ public class JoomlaHugoConverter {
         logger.info("Category description creation complete");
     }
 
+
+    private void performCustomHtmlModulesConversion() {
+        String sqlCustomHtmlModules =
+                "SELECT id, title, content, position, publish_up AS created_time, published\n" +
+                "FROM REPLSTR_modules\n" +
+                "WHERE module = \'mod_custom\'\n";
+        sqlCustomHtmlModules = sqlCustomHtmlModules.replace("REPLSTR", dbExtension);
+        List<JoomlaContent> content = template.query(sqlCustomHtmlModules, (resultSet, i) -> new JoomlaContent(
+                resultSet.getInt("id"),
+                resultSet.getInt("published"),
+                null,
+                null,
+                null,
+                "",
+                resultSet.getString("content"),
+                "customHtmlModules",
+                resultSet.getString("title"),
+                "",
+                resultSet.getString("title"),
+                "{}",
+                null
+        ));
+
+        content.stream().filter(JoomlaContent::isPublished).forEach(c-> {
+            nastyContentChecker.checkForNastyContent(c);
+            Path path = Paths.get(pathToOutput);
+            logger.info("processing custom HTML module {}", c.getTitle());
+            Path newPath = path.resolve(c.getCategory());
+            newPath.toFile().mkdirs();
+            buildTomlOutput(c, newPath.resolve(c.getAlias() + ".md"), customHtmlModuleTemplate, false);
+
+            
+        });
+
+        logger.info("Custom HTML modules creation complete");
+    }
 
     public void buildTomlOutput(JoomlaContent content, Path resolve, Template template, Boolean convertBodyToMarkdown)  {
 

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -204,7 +204,7 @@ public class JoomlaHugoConverter {
             nastyContentChecker.checkForNastyContent(c);
             Path path = Paths.get(pathToOutput);
             logger.info("processing custom HTML module {}", c.getTitle());
-            Path newPath = path.resolve(c.getCategory());
+            Path newPath = path.resolve("layout/shortcodes");
             newPath.toFile().mkdirs();
             buildTomlOutput(c, newPath.resolve(c.getAlias() + ".md"), customHtmlModuleTemplate, false);
 

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -206,7 +206,7 @@ public class JoomlaHugoConverter {
             nastyContentChecker.checkForNastyContent(c);
             Path path = Paths.get(pathToOutput);
             logger.info("processing custom HTML module {}", c.getTitle());
-            Path newPath = path.resolve(c.getCategory());
+            Path newPath = path.resolve("layout/shortcodes");
             newPath.toFile().mkdirs();
             buildTomlOutput(c, newPath.resolve(c.getAlias() + ".md"), customHtmlModuleTemplate, false);
 

--- a/src/main/resources/customHtmlModule.yaml.ftl
+++ b/src/main/resources/customHtmlModule.yaml.ftl
@@ -1,8 +1,3 @@
 <#-- @ftlvariable name="joomlaData" type="com.thecoderscorner.web.hugojoomla.JoomlaContent" -->
----
-title: "${joomlaData.title}"
-type: "module"
-weight: 10
----
 
 ${body}

--- a/src/main/resources/customHtmlModule.yaml.ftl
+++ b/src/main/resources/customHtmlModule.yaml.ftl
@@ -1,0 +1,8 @@
+<#-- @ftlvariable name="joomlaData" type="com.thecoderscorner.web.hugojoomla.JoomlaContent" -->
+---
+title: "${joomlaData.title}"
+type: "module"
+weight: 10
+---
+
+${body}

--- a/src/main/resources/hugoJoomla.xml
+++ b/src/main/resources/hugoJoomla.xml
@@ -11,7 +11,7 @@
     </util:properties>
 
     <bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
-        <property name="driverClassName" value="com.mysql.jdbc.Driver" />
+        <property name="driverClassName" value="com.mysql.cj.jdbc.Driver" />
         <property name="url" value="#{systemProperties['db.url']}" />
         <property name="username" value="#{systemProperties['db.user']}" />
         <property name="password" value="#{systemProperties['db.pass']}" />


### PR DESCRIPTION
- Extraction of active custom HTML modules from joomla and conversion to shortcode (raw HTML, no markdown conversion)
- Fixed deprecated mysql driverClassName after driver update
