### PR TITLE
Fix/utf8 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
     <name>Hugo-Joomla</name>
     <description>Hugo generation from Joomla database</description>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
+++ b/src/main/java/com/thecoderscorner/web/hugojoomla/JoomlaHugoConverter.java
@@ -15,10 +15,12 @@ import io.github.furstenheim.HeadingStyle;
 import io.github.furstenheim.CodeBlockStyle;
 
 import java.io.BufferedWriter;
-import java.io.FileWriter;
+import java.io.OutputStreamWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +198,7 @@ public class JoomlaHugoConverter {
             root.put("joomlaData", content);
             root.put("tags", tagsQuoted);
             root.put("body", body);
-            template.process(root, new BufferedWriter(new FileWriter(resolve.toFile())));
+            template.process(root, new BufferedWriter(new OutputStreamWriter(new FileOutputStream(resolve.toFile(), true), StandardCharsets.UTF_8)));
         } catch (Exception e) {
             logger.error("Failed to generate file", e);
         }


### PR DESCRIPTION
- Fixed encoding warning message during build. 
- Explicit UTF-8 encoding of generated html and markdown files